### PR TITLE
feat: configure secure mqtt connection with azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,4 +292,3 @@ _deps
 /.vscode/
 
 build/*
-/lib/

--- a/lib/README
+++ b/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = nodemcuv2
+description = Almond hydroponics device connection
 
 [common_env_data]
 build_flags =
@@ -27,7 +28,7 @@ upload_port = /dev/ttyUSB0
 ; Custom Serial Monitor port
 monitor_port = /dev/ttyUSB0
 ; Custom Serial Monitor speed (baud rate)
-monitor_speed = 9600
+monitor_speed = 115200
 
 lib_deps =
     ; RTClib@1.3.3


### PR DESCRIPTION
#### Description
This PR adds a secure mqtt connection with azure IoT hub. The purpose for the change is for testing the connection to check if its' a viable method as opposed to create an own mqtt connection through digital ocean.

#### Type of change
<pre>
+ Added something.
- Removed something.
~ Modified something.
? Found a bug, but didn't fix it.
! Found a bug AND fixed it, or fixed a previously known bug.
</pre>

#### How Has This Been Tested?
n/a

#### Story ID
n/a
